### PR TITLE
feat: add safe autoconnect

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { WagmiConfig, configureChains, createConfig } from "wagmi";
 import { arbitrum, goerli, mainnet, optimism, polygon } from "wagmi/chains";
 import { publicProvider } from "wagmi/providers/public";
+import { SafeAutoConnect } from "../hooks/useSafeAutoConnect";
 
 const { chains, publicClient, webSocketPublicClient } = configureChains(
   [
@@ -63,7 +64,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <WagmiConfig config={wagmiConfig}>
       <RainbowKitProvider chains={chains} appInfo={demoAppInfo}>
-        {mounted && children}
+        <SafeAutoConnect>{mounted && children}</SafeAutoConnect>
       </RainbowKitProvider>
     </WagmiConfig>
   );

--- a/src/hooks/useSafeAutoConnect.ts
+++ b/src/hooks/useSafeAutoConnect.ts
@@ -1,0 +1,30 @@
+"use client";
+import { useConnect, useAccount } from "wagmi";
+import React, { useEffect } from "react";
+
+const AUTOCONNECTED_CONNECTOR_IDS = ["safe"];
+
+// this is ripped from https://github.com/safe-global/safe-apps-sdk/blob/main/examples/wagmi/src/useAutoConnect.ts
+function useSafeAutoConnect() {
+  const { connect, connectors } = useConnect();
+
+  useEffect(() => {
+    AUTOCONNECTED_CONNECTOR_IDS.forEach((connector) => {
+      const connectorInstance = connectors.find(
+        (c) => c.id === connector && c.ready,
+      );
+
+      if (connectorInstance) {
+        connect({ connector: connectorInstance });
+      }
+    });
+  }, [connect, connectors]);
+}
+
+// Small wrapper function to add a pass through to the providers
+function SafeAutoConnect({ children }: { children: React.ReactNode }) {
+  useSafeAutoConnect();
+  return children;
+}
+
+export { useSafeAutoConnect, SafeAutoConnect };


### PR DESCRIPTION
## motivation
we dont actually want to connect to any other wallet than the gnosis safe, so we can do this automatically if we detect it

## changes
this copies autoconnect code from the safe example repo, and a small component to have the  hook auto run on the client side

![image](https://github.com/UMAprotocol/osnap-safe-app/assets/4429761/5e6025db-8f09-4cf7-81be-b87841445dcb)
