### PR TITLE
improve: update osnap enable after txs

### DIFF
--- a/src/hooks/OptimisticGovernor.ts
+++ b/src/hooks/OptimisticGovernor.ts
@@ -81,14 +81,15 @@ export function useOgDeployer(initialConfig?: Partial<OgDeployerConfig>) {
       // TODO: see if we can use wagmi instead, probably need to use multicall here
       safeSdk.txs
         .send({ txs })
-        .then((result) => {
-          console.log("deployment successful", result);
+        .then(() => {
+          // show that osnap is now enabled once tx completes
+          return enabled.mutate(true, { revalidate: false });
         })
         .catch((err) => {
           console.error("deployment error", err);
         });
     };
-  }, [config, address, chain?.id, publicClient, isActive]);
+  }, [config, address, chain?.id, publicClient, isActive, enabled]);
   return {
     config,
     setConfig,
@@ -219,7 +220,7 @@ export function useOgState() {
 }
 
 export function useOgDisabler() {
-  const { moduleAddress, safeAddress } = useOgState();
+  const { moduleAddress, safeAddress, enabled } = useOgState();
   const ogAddress = moduleAddress.data;
 
   const disable = useMemo(() => {
@@ -230,17 +231,17 @@ export function useOgDisabler() {
 
     return () => {
       const txs = [disableModule(safeAddress, ogAddress)];
-      // TODO: see if we can use wagmi instead, probably need to use multicall here
       safeSdk.txs
         .send({ txs })
-        .then((result) => {
-          console.log("disabling successful", result);
+        .then(() => {
+          // show that osnap is now disabled once tx completes
+          return enabled.mutate(false, { revalidate: false });
         })
         .catch((err) => {
           console.error("disabling error", err);
         });
     };
-  }, [safeAddress, ogAddress]);
+  }, [safeAddress, ogAddress, enabled]);
   return {
     disable,
   };


### PR DESCRIPTION
## motivation
currently we get enabled status from subgraph, but this is stale when submitting a tx to change osnap install state.

## changes
we do a client side mutation with no revalidation once a tx succeeds for both disable and enabling osnap.