### PR TITLE
fix: fix advanced form for default values and editability

### DIFF
--- a/src/components/AdvancedSettingsModal.tsx
+++ b/src/components/AdvancedSettingsModal.tsx
@@ -80,15 +80,14 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
     });
     props.closeModal();
   };
-
   return (
     <Modal {...props}>
       <div className="max-w-[520px] p-6">
         <h1 className="mb-4 text-lg font-semibold">Advanced settings</h1>
         {!disabled && (
           <p className="mb-6 rounded-lg  border bg-warning-50 px-3 py-2 text-sm text-warning-700">
-            Note that these are advanced settings that should be adjusted with
-            caution.
+            Defaults are set to allow automatic proposal execution therefore
+            these settings should be adjusted with caution!
           </p>
         )}
         <Heading>Snapshot Space URL</Heading>
@@ -98,13 +97,13 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
         <form action="" method="dialog" onSubmit={onSubmit}>
           <div className="grid grid-cols-1 gap-x-6 gap-y-7 md:grid-cols-2">
             <RadioDropdown
-              label="Currency"
+              label="Bond Currency"
               items={currencyOptions}
               selected={collateralCurrency}
               onSelect={setCollateralCurrency}
-              disabled
+              disabled={disabled}
             />
-            <NumberInput {...bondInputProps} disabled />
+            <NumberInput {...bondInputProps} disabled={disabled} />
             <RadioDropdown
               label="Challenge period"
               items={challengePeriodOptions}
@@ -112,9 +111,9 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
               onSelect={(item) => {
                 setChallengePeriod(challengePeriodFromDropdownOption(item));
               }}
-              disabled
+              disabled={disabled}
             />
-            <NumberInput {...quorumInputProps} disabled />
+            <NumberInput {...quorumInputProps} disabled={disabled} />
           </div>
           {!disabled && (
             <button

--- a/src/constants/challengePeriods.ts
+++ b/src/constants/challengePeriods.ts
@@ -1,19 +1,24 @@
 export const challengePeriods = [
+  // first one is the default that will show up in dropdown
   {
-    text: "2 hours",
-    seconds: "7200",
+    text: "5 Days",
+    seconds: "432000",
   },
   {
-    text: "8 hours",
-    seconds: "28800",
+    text: "72 hours",
+    seconds: "259200",
+  },
+  {
+    text: "48 hours",
+    seconds: "172800",
   },
   {
     text: "24 hours",
     seconds: "86400",
   },
   {
-    text: "48 hours",
-    seconds: "172800",
+    text: "8 hours",
+    seconds: "28800",
   },
 ] as const;
 

--- a/src/constants/currencies.ts
+++ b/src/constants/currencies.ts
@@ -1,4 +1,4 @@
-export const currencies = ["USDC", "WETH"] as const;
+export const currencies = ["WETH", "USDC"] as const;
 export type Currencies = typeof currencies;
 export type Currency = Currencies[number];
 

--- a/src/hooks/OptimisticGovernor.ts
+++ b/src/hooks/OptimisticGovernor.ts
@@ -24,7 +24,7 @@ export function ogDeployerConfigDefaults(
   config?: Partial<OgDeployerConfig>,
 ): OgDeployerConfig {
   return {
-    bondAmount: config?.bondAmount ?? "1000",
+    bondAmount: config?.bondAmount ?? "2",
     challengePeriod: config?.challengePeriod ?? challengePeriods[0],
     collateralCurrency: config?.collateralCurrency ?? currencies[0],
     quorum: config?.quorum ?? "5",


### PR DESCRIPTION
## motivation
the advanced settings in the dapp was not editable, and the defaults were not correct

## changes
set the right defaults ( 2 weth) and a longer challenge period ( 5 days ).  also updated the list of potential dispute periods and got rid of 2 hours which seemed way to short.  also the form was not enabled, this was a bug

old form:
![image](https://github.com/UMAprotocol/osnap-safe-app/assets/4429761/fcd8d718-2ac2-4f0a-80ca-4746b08e79a4)

new form
![image](https://github.com/UMAprotocol/osnap-safe-app/assets/4429761/10235154-9a98-4b3a-bb66-9e3ebf56e34f)

