### PR TITLE
fix: advanced settings

### DIFF
--- a/src/components/AdvancedSettingsModal.tsx
+++ b/src/components/AdvancedSettingsModal.tsx
@@ -68,15 +68,29 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
     placeholder: "5",
     required: true,
   });
+  const votingPeriodInputProps = useNumberInput({
+    label: "Voting Period hours",
+    initialValue: props.config.votingPeriodHours,
+    isWholeNumber: true,
+    min: 1,
+    placeholder: "24",
+    required: true,
+  });
 
   const onSubmit: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
-    if (!bondInputProps.valid || !quorumInputProps.valid) return;
+    if (
+      !bondInputProps.valid ||
+      !quorumInputProps.valid ||
+      !votingPeriodInputProps.valid
+    )
+      return;
     props.setConfig((draft) => {
       draft.challengePeriod = challengePeriod;
       draft.collateralCurrency = collateralCurrency.value;
       draft.bondAmount = bondInputProps.value;
       draft.quorum = quorumInputProps.value;
+      draft.votingPeriodHours = votingPeriodInputProps.value;
     });
     props.closeModal();
   };
@@ -104,6 +118,8 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
               disabled={disabled}
             />
             <NumberInput {...bondInputProps} disabled={disabled} />
+            <NumberInput {...quorumInputProps} disabled={disabled} />
+            <NumberInput {...votingPeriodInputProps} disabled={disabled} />
             <RadioDropdown
               label="Challenge period"
               items={challengePeriodOptions}
@@ -113,13 +129,16 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
               }}
               disabled={disabled}
             />
-            <NumberInput {...quorumInputProps} disabled={disabled} />
           </div>
           {!disabled && (
             <button
               type="submit"
               formMethod="dialog"
-              disabled={!bondInputProps.valid || !quorumInputProps.valid}
+              disabled={
+                !bondInputProps.valid ||
+                !quorumInputProps.valid ||
+                !votingPeriodInputProps.valid
+              }
               className="mt-6 grid w-full place-items-center rounded-lg bg-gray-900 px-5 py-3 font-semibold text-white transition hover:brightness-200 disabled:cursor-not-allowed disabled:bg-gray-400 disabled:hover:brightness-100"
             >
               Save

--- a/src/constants/challengePeriods.ts
+++ b/src/constants/challengePeriods.ts
@@ -1,10 +1,6 @@
 export const challengePeriods = [
   // first one is the default that will show up in dropdown
   {
-    text: "5 Days",
-    seconds: "432000",
-  },
-  {
     text: "72 hours",
     seconds: "259200",
   },

--- a/src/hooks/OptimisticGovernor.ts
+++ b/src/hooks/OptimisticGovernor.ts
@@ -28,6 +28,7 @@ export function ogDeployerConfigDefaults(
     challengePeriod: config?.challengePeriod ?? challengePeriods[0],
     collateralCurrency: config?.collateralCurrency ?? currencies[0],
     quorum: config?.quorum ?? "5",
+    votingPeriodHours: config?.votingPeriodHours ?? "24",
     spaceUrl: config?.spaceUrl ?? undefined,
   };
 }
@@ -44,6 +45,7 @@ export function useOgDeployer(initialConfig?: Partial<OgDeployerConfig>) {
       bondAmount,
       spaceUrl,
       quorum,
+      votingPeriodHours,
       challengePeriod,
       collateralCurrency,
     } = config;
@@ -53,6 +55,7 @@ export function useOgDeployer(initialConfig?: Partial<OgDeployerConfig>) {
       !bondAmount.length ||
       !spaceUrl?.length ||
       !quorum.length ||
+      !votingPeriodHours.length ||
       !collateralCurrency.length ||
       isActive ||
       address === undefined ||
@@ -76,7 +79,7 @@ export function useOgDeployer(initialConfig?: Partial<OgDeployerConfig>) {
         liveness: challengePeriod.seconds,
         spaceUrl,
         quorum,
-        challengePeriodText: challengePeriod.text,
+        votingPeriodHours,
       });
       // TODO: see if we can use wagmi instead, probably need to use multicall here
       safeSdk.txs

--- a/src/libs/ogUtils.ts
+++ b/src/libs/ogUtils.ts
@@ -30,9 +30,9 @@ export const formatUnits = ethers.utils.formatUnits;
 export function defaultRules(params: {
   spaceUrl: string;
   quorum: string;
-  challengePeriodText: string;
+  votingPeriodHours: string;
 }) {
-  return `I assert that this transaction proposal is valid according to the following rules: Proposals approved on Snapshot, as verified at ${params.spaceUrl}, are valid as long as there is a minimum quorum of ${params.quorum} and a minimum voting period of ${params.challengePeriodText} and it does not appear that the Snapshot voting system is being exploited or is otherwise unavailable. The quorum and voting period are minimum requirements for a proposal to be valid. Quorum and voting period values set for a specific proposal in Snapshot should be used if they are more strict than the rules parameter. The explanation included with the on-chain proposal must be the unique IPFS identifier for the specific Snapshot proposal that was approved or a unique identifier for a proposal in an alternative voting system approved by DAO social consensus if Snapshot is being exploited or is otherwise unavailable.`;
+  return `I assert that this transaction proposal is valid according to the following rules: Proposals approved on Snapshot, as verified at ${params.spaceUrl}, are valid as long as there is a minimum quorum of ${params.quorum} and a minimum voting period of ${params.votingPeriodHours} hours and it does not appear that the Snapshot voting system is being exploited or is otherwise unavailable. The quorum and voting period are minimum requirements for a proposal to be valid. Quorum and voting period values set for a specific proposal in Snapshot should be used if they are more strict than the rules parameter. The explanation included with the on-chain proposal must be the unique IPFS identifier for the specific Snapshot proposal that was approved or a unique identifier for a proposal in an alternative voting system approved by DAO social consensus if Snapshot is being exploited or is otherwise unavailable.`;
 }
 
 // https://github.com/gnosis/zodiac-safe-app/blob/0dfeac33b8e95af566c7ff7b1d77017071219599/packages/app/src/services/index.ts#L477
@@ -63,7 +63,7 @@ export type OgDeploymentTxsParams = {
   liveness: string;
   spaceUrl: string;
   quorum: string;
-  challengePeriodText: string;
+  votingPeriodHours: string;
 };
 export function ogDeploymentTxs(params: OgDeploymentTxsParams) {
   const {
@@ -76,7 +76,7 @@ export function ogDeploymentTxs(params: OgDeploymentTxsParams) {
     liveness,
     spaceUrl,
     quorum,
-    challengePeriodText,
+    votingPeriodHours,
   } = params;
 
   // make sure we have the collateral defined in contracts
@@ -90,7 +90,7 @@ export function ogDeploymentTxs(params: OgDeploymentTxsParams) {
   });
 
   const bondWei = parseUnits(bond, decimals).toString();
-  const rules = defaultRules({ spaceUrl, quorum, challengePeriodText });
+  const rules = defaultRules({ spaceUrl, quorum, votingPeriodHours });
 
   const {
     transaction: daoModuleDeploymentTx,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -7,5 +7,6 @@ export type OgDeployerConfig = {
   bondAmount: string; // bond in decimals like 3500.99 usdc
   challengePeriod: ChallengePeriod; // challenge period in seconds with text description
   quorum: string; // voting quorum
+  votingPeriodHours: string; // minimum voting period in integer hours
   rules?: string | undefined;
 };


### PR DESCRIPTION
Currently, in the advanced settings the voting period and challenge period are assigned the same value, but the two are unrelated.

This fix:
-Adds option for setting voting period in advanced settings UI decoupled from challenge period
-Sets default challenge period to 72 hours

Partially addresses https://linear.app/uma/issue/UMA-2054/update-default-parameters-for-voting-period-quorum-and-challenge#comment-9b26ce6d
Syncing app state and Snapshot settings for quorum and voting period are left for follow-up PR as this might be more involved.