### PR TITLE
fix: wait for tx to confirm mining before changing status

### DIFF
--- a/src/libs/ogUtils.ts
+++ b/src/libs/ogUtils.ts
@@ -138,3 +138,7 @@ export function ogDeploymentTxs(params: OgDeploymentTxsParams) {
   daoModuleTransactions.push(enableDaoModuleTransaction);
   return daoModuleTransactions;
 }
+
+export function sleep(ms = 0) {
+  return new Promise((res) => setTimeout(res, ms));
+}


### PR DESCRIPTION
## motivation
The local state of the app was changing as soon as user submitted tx to enable or disable, it was not correctly waiting for transactioin to mine before flipping state

## changes
this properly waits for the safe tx to mine. it also disables the button while tx is mining, and changes the label for the button. it also changes the pill to a new color to representing a pending state.

![image](https://github.com/UMAprotocol/osnap-safe-app/assets/4429761/0b7d53c9-7f44-4d74-9ce1-71f2b89606e4)
![image](https://github.com/UMAprotocol/osnap-safe-app/assets/4429761/3a634fcb-c43b-4c33-8ec1-7ee357a9d5d8)
