### PR TITLE
update link to setup process in docs

### DIFF
--- a/src/components/OsnapCard.tsx
+++ b/src/components/OsnapCard.tsx
@@ -104,7 +104,7 @@ export function OsnapCard() {
         Read more about the full setup process{" "}
         <Link
           target="_blank"
-          href="https://uma.xyz/osnap"
+          href="https://docs.uma.xyz/developers/osnap/osnap-deployment-tutorial"
           className="text-primary-500 hover:underline"
         >
           here.


### PR DESCRIPTION
## motivation

new osnap users were being directed to the osnap landing page when they should be directed to the docs page so they may be better informed as to how to setup the osnap safe module.