### PR TITLE
feat: show warning/s for non-standard osnap settings for bot support

### DIFF
--- a/src/app/api/space-config/route.ts
+++ b/src/app/api/space-config/route.ts
@@ -6,6 +6,13 @@ import { Address } from "viem";
 
 /**
  * Check if a space's deployed (on-chain) settings are supported by our bots.
+ *
+ * ### Query Params:
+ * 1. address - the safe address.
+ * 2. chainId - network for the safe.
+ *
+ * example url:
+ *  https://osnap.uma.xyz/api/space-config?address=0xa690212421298fa7431c64f4b5ff8aa4e4a7e74e&chainId=137
  */
 export async function GET(req: NextRequest) {
   try {

--- a/src/app/api/space-config/route.ts
+++ b/src/app/api/space-config/route.ts
@@ -4,6 +4,9 @@ import { isErrorWithMessage, isHttpError } from "@/types/guards";
 import { getModuleConfig, isConfigStandard, parseParams } from "./utils";
 import { Address } from "viem";
 
+/**
+ * Check if a space's deployed (on-chain) settings are supported by our bots.
+ */
 export async function GET(req: NextRequest) {
   try {
     const { chainId, address } = parseParams(req.nextUrl.searchParams);

--- a/src/app/api/space-config/route.ts
+++ b/src/app/api/space-config/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Client as SubgraphClient } from "@/libs/ogSubgraph";
+import { isErrorWithMessage, isHttpError } from "@/types/guards";
+import { isConfigStandard, parseParams } from "./utils";
+import { Address } from "viem";
+
+export async function GET(req: NextRequest) {
+  try {
+    const { chainId, address } = parseParams(req.nextUrl.searchParams);
+
+    // get subgraph client for network
+    const { getModuleAddress } = SubgraphClient(chainId);
+
+    // use safe Address to find oSnap module address
+    const moduleAddress = await getModuleAddress(address);
+
+    if (!moduleAddress) {
+      throw new Error("No module deployed for this safe", { cause: 404 });
+    }
+
+    const moduleConfig = await isConfigStandard(
+      moduleAddress as Address,
+      chainId,
+    );
+
+    return NextResponse.json({
+      moduleConfig,
+      status: 200,
+    });
+  } catch (error) {
+    // catch and rethrow with specific error codes, eg. in validation
+    if (isHttpError(error)) {
+      return NextResponse.json({
+        error: error.message,
+        status: error.cause,
+      });
+    }
+
+    return NextResponse.json({
+      error: isErrorWithMessage(error) ? error.message : "Unknown error",
+      status: 500,
+    });
+  }
+}

--- a/src/app/api/space-config/route.ts
+++ b/src/app/api/space-config/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Client as SubgraphClient } from "@/libs/ogSubgraph";
 import { isErrorWithMessage, isHttpError } from "@/types/guards";
-import { isConfigStandard, parseParams } from "./utils";
+import { getModuleConfig, isConfigStandard, parseParams } from "./utils";
 import { Address } from "viem";
 
 export async function GET(req: NextRequest) {
@@ -18,12 +18,14 @@ export async function GET(req: NextRequest) {
       throw new Error("No module deployed for this safe", { cause: 404 });
     }
 
-    const moduleConfig = await isConfigStandard(
+    const moduleConfig = await getModuleConfig(
       moduleAddress as Address,
       chainId,
     );
 
-    return NextResponse.json(moduleConfig, { status: 200 });
+    const isStandard = isConfigStandard({ ...moduleConfig, chainId });
+
+    return NextResponse.json(isStandard, { status: 200 });
   } catch (error) {
     // catch and rethrow with specific error codes, eg. in validation
     if (isHttpError(error)) {

--- a/src/app/api/space-config/route.ts
+++ b/src/app/api/space-config/route.ts
@@ -23,22 +23,27 @@ export async function GET(req: NextRequest) {
       chainId,
     );
 
-    return NextResponse.json({
-      moduleConfig,
-      status: 200,
-    });
+    return NextResponse.json(moduleConfig, { status: 200 });
   } catch (error) {
     // catch and rethrow with specific error codes, eg. in validation
     if (isHttpError(error)) {
-      return NextResponse.json({
-        error: error.message,
-        status: error.cause,
-      });
+      return NextResponse.json(
+        {
+          error: error.message,
+        },
+        {
+          status: error.cause,
+        },
+      );
     }
 
-    return NextResponse.json({
-      error: isErrorWithMessage(error) ? error.message : "Unknown error",
-      status: 500,
-    });
+    return NextResponse.json(
+      {
+        error: isErrorWithMessage(error) ? error.message : "Unknown error",
+      },
+      {
+        status: 500,
+      },
+    );
   }
 }

--- a/src/app/api/space-config/utils.ts
+++ b/src/app/api/space-config/utils.ts
@@ -1,0 +1,128 @@
+import {
+  OptimisticGovernorAbi,
+  contractDataList,
+  findContract,
+  getPublicClient,
+} from "@/libs";
+import { Address, formatUnits, isAddress, isAddressEqual } from "viem";
+
+const BOND_TOKEN_NAME = "WETH";
+const BOND_AMOUNT = 2;
+
+export function rulesMatch(rules: string): boolean {
+  // This is based on the template from Zodiac app at
+  // https://github.com/gnosis/zodiac-safe-app/blob/79dbb72af506f60fcc16599516ce48f893393b29/packages/app/src/views/AddModule/wizards/OptimisticGovernorModule/OptimisticGovernorModuleModal.tsx#L136
+
+  const regex =
+    /^I assert that this transaction proposal is valid according to the following rules: Proposals approved on Snapshot, as verified at https:\/\/snapshot\.org\/#\/([a-zA-Z0-9-.]+)\/?, are valid as long as there is a minimum quorum of (\d+) and a minimum voting period of (\d+) hours and it does not appear that the Snapshot voting system is being exploited or is otherwise unavailable\. The quorum and voting period are minimum requirements for a proposal to be valid\. Quorum and voting period values set for a specific proposal in Snapshot should be used if they are more strict than the rules parameter\. The explanation included with the on-chain proposal must be the unique IPFS identifier for the specific Snapshot proposal that was approved or a unique identifier for a proposal in an alternative voting system approved by DAO social consensus if Snapshot is being exploited or is otherwise unavailable.$/;
+
+  return regex.test(rules);
+}
+
+export function parseParams(params: URLSearchParams) {
+  const address = params.get("address");
+  const chainId = params.get("chainId");
+  const supportedNetworks = contractDataList.map((chain) => chain.chainId);
+
+  if (!chainId) {
+    throw new Error("no chainId in query", { cause: 400 });
+  }
+  if (!address) {
+    throw new Error("no address in query", { cause: 400 });
+  }
+
+  if (!isAddress(address)) {
+    throw new Error("Invalid address in query", { cause: 400 });
+  }
+  if (!supportedNetworks.includes(parseInt(chainId))) {
+    throw new Error("Network not supported", { cause: 400 });
+  }
+
+  return {
+    chainId: parseInt(chainId),
+    address: address,
+  };
+}
+
+export async function getModuleConfig(moduleAddress: Address, chainId: number) {
+  const provider = getPublicClient(chainId);
+
+  if (!provider) {
+    throw new Error("Network not supported");
+  }
+
+  const config = {
+    address: moduleAddress,
+    abi: OptimisticGovernorAbi,
+  };
+
+  const [rules, bondAmount, collateral] = await Promise.all([
+    provider.readContract({
+      ...config,
+      functionName: "rules",
+    }),
+    provider.readContract({
+      ...config,
+      functionName: "bondAmount",
+    }),
+    provider.readContract({
+      ...config,
+      functionName: "collateral",
+    }),
+  ]);
+
+  return {
+    rules,
+    bondAmount,
+    collateral,
+  };
+}
+
+type Response =
+  | {
+      automaticExecution: true;
+    }
+  | {
+      automaticExecution: false;
+      rules: boolean;
+      bondToken: boolean;
+      bondAmount: boolean;
+    };
+
+export async function isConfigStandard(
+  moduleAddress: Address,
+  chainId: number,
+): Promise<Response> {
+  const { rules, bondAmount, collateral } = await getModuleConfig(
+    moduleAddress,
+    chainId,
+  );
+
+  const rulesStandard = rulesMatch(rules);
+
+  // find weth for network
+  const weth = findContract({
+    chainId: chainId,
+    name: BOND_TOKEN_NAME,
+  });
+  // check if address is correct
+  const isWeth = isAddressEqual(collateral, weth.address);
+
+  // check if amount is correct
+
+  const isCorrectAmount =
+    formatUnits(bondAmount, weth.decimals ?? 18) === BOND_AMOUNT.toString();
+
+  if (rulesStandard && isWeth && isCorrectAmount) {
+    return {
+      automaticExecution: true,
+    };
+  }
+
+  return {
+    automaticExecution: false,
+    rules: rulesStandard,
+    bondToken: isWeth,
+    bondAmount: isCorrectAmount,
+  };
+}

--- a/src/app/api/space-config/utils.ts
+++ b/src/app/api/space-config/utils.ts
@@ -9,7 +9,7 @@ import { Address, formatUnits, isAddress, isAddressEqual } from "viem";
 const BOND_TOKEN_NAME = "WETH";
 const BOND_AMOUNT = 2;
 
-export function rulesMatch(rules: string): boolean {
+function rulesMatch(rules: string): boolean {
   // This is based on the template from Zodiac app at
   // https://github.com/gnosis/zodiac-safe-app/blob/79dbb72af506f60fcc16599516ce48f893393b29/packages/app/src/views/AddModule/wizards/OptimisticGovernorModule/OptimisticGovernorModuleModal.tsx#L136
 
@@ -44,7 +44,7 @@ export function parseParams(params: URLSearchParams) {
   };
 }
 
-export async function getModuleConfig(moduleAddress: Address, chainId: number) {
+async function getModuleConfig(moduleAddress: Address, chainId: number) {
   const provider = getPublicClient(chainId);
 
   if (!provider) {
@@ -78,7 +78,7 @@ export async function getModuleConfig(moduleAddress: Address, chainId: number) {
   };
 }
 
-type Response =
+export type SpaceConfigResponse =
   | {
       automaticExecution: true;
     }
@@ -92,7 +92,7 @@ type Response =
 export async function isConfigStandard(
   moduleAddress: Address,
   chainId: number,
-): Promise<Response> {
+): Promise<SpaceConfigResponse> {
   const { rules, bondAmount, collateral } = await getModuleConfig(
     moduleAddress,
     chainId,

--- a/src/app/api/space-config/utils.ts
+++ b/src/app/api/space-config/utils.ts
@@ -124,3 +124,15 @@ export function isConfigStandard(params: {
     bondAmount: isCorrectAmount,
   };
 }
+
+export function isOriginAllowed(origin: string) {
+  // allow all origins in dev & preview
+  if (process.env.VERCEL_ENV !== "production") {
+    return true;
+  }
+  return (
+    origin.endsWith("snapshot.org") ||
+    origin.endsWith("snapshot.vercel.app") ||
+    origin.endsWith("uma.vercel.app")
+  );
+}

--- a/src/app/api/space-config/utils.ts
+++ b/src/app/api/space-config/utils.ts
@@ -10,8 +10,8 @@ const BOND_TOKEN_NAME = "WETH";
 const BOND_AMOUNT = 2;
 
 function rulesMatch(rules: string): boolean {
-  // This is based on the template from Zodiac app at
-  // https://github.com/gnosis/zodiac-safe-app/blob/79dbb72af506f60fcc16599516ce48f893393b29/packages/app/src/views/AddModule/wizards/OptimisticGovernorModule/OptimisticGovernorModuleModal.tsx#L136
+  // This is based on the rules regex from protocol
+  // https://github.com/UMAprotocol/protocol/blob/bc7aef9dc60190909036e1418647f429f3702096/packages/monitor-v2/src/monitor-og/SnapshotVerification.ts#L274
 
   const regex =
     /^I assert that this transaction proposal is valid according to the following rules: Proposals approved on Snapshot, as verified at https:\/\/snapshot\.org\/#\/([a-zA-Z0-9-.]+)\/?, are valid as long as there is a minimum quorum of (\d+) and a minimum voting period of (\d+) hours and it does not appear that the Snapshot voting system is being exploited or is otherwise unavailable\. The quorum and voting period are minimum requirements for a proposal to be valid\. Quorum and voting period values set for a specific proposal in Snapshot should be used if they are more strict than the rules parameter\. The explanation included with the on-chain proposal must be the unique IPFS identifier for the specific Snapshot proposal that was approved or a unique identifier for a proposal in an alternative voting system approved by DAO social consensus if Snapshot is being exploited or is otherwise unavailable.$/;

--- a/src/app/api/space-config/utils.ts
+++ b/src/app/api/space-config/utils.ts
@@ -44,7 +44,7 @@ export function parseParams(params: URLSearchParams) {
   };
 }
 
-async function getModuleConfig(moduleAddress: Address, chainId: number) {
+export async function getModuleConfig(moduleAddress: Address, chainId: number) {
   const provider = getPublicClient(chainId);
 
   if (!provider) {
@@ -89,29 +89,27 @@ export type SpaceConfigResponse =
       bondAmount: boolean;
     };
 
-export async function isConfigStandard(
-  moduleAddress: Address,
-  chainId: number,
-): Promise<SpaceConfigResponse> {
-  const { rules, bondAmount, collateral } = await getModuleConfig(
-    moduleAddress,
-    chainId,
-  );
-
-  const rulesStandard = rulesMatch(rules);
+export function isConfigStandard(params: {
+  rules: string;
+  bondAmount: bigint;
+  collateral: Address;
+  chainId: number;
+}): SpaceConfigResponse {
+  const rulesStandard = rulesMatch(params.rules);
 
   // find weth for network
   const weth = findContract({
-    chainId: chainId,
+    chainId: params.chainId,
     name: BOND_TOKEN_NAME,
   });
   // check if address is correct
-  const isWeth = isAddressEqual(collateral, weth.address);
+  const isWeth = isAddressEqual(params.collateral, weth.address);
 
   // check if amount is correct
 
   const isCorrectAmount =
-    formatUnits(bondAmount, weth.decimals ?? 18) === BOND_AMOUNT.toString();
+    formatUnits(params.bondAmount, weth.decimals ?? 18) ===
+    BOND_AMOUNT.toString();
 
   if (rulesStandard && isWeth && isCorrectAmount) {
     return {

--- a/src/components/AdvancedSettingsModal.tsx
+++ b/src/components/AdvancedSettingsModal.tsx
@@ -158,12 +158,6 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
       <div className="max-w-[520px] p-6">
         <h1 className="mb-4 text-lg font-semibold">Advanced settings</h1>
         <StandardConfigWarning isStandard={configIsStandard} />
-        {/* {!disabled && (
-          <p className="mb-6 rounded-lg  border bg-warning-50 px-3 py-2 text-sm text-warning-700">
-            Defaults are set to allow automatic proposal execution therefore
-            these settings should be adjusted with caution!
-          </p>
-        )} */}
         <Heading>Snapshot Space URL</Heading>
         <p className="mb-6 rounded-lg border border-gray-300 bg-white px-3 py-2 opacity-50 shadow-xs">
           {props.config.spaceUrl}

--- a/src/components/AdvancedSettingsModal.tsx
+++ b/src/components/AdvancedSettingsModal.tsx
@@ -64,6 +64,7 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
     initialValue: props.config.bondAmount,
     required: true,
   });
+
   const quorumInputProps = useNumberInput({
     label: "Voting Quorum",
     initialValue: props.config.quorum,
@@ -140,10 +141,13 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
     });
     props.closeModal();
   };
+
+  // TODO: show auto execution warning
   return (
     <Modal {...props}>
       <div className="max-w-[520px] p-6">
         <h1 className="mb-4 text-lg font-semibold">Advanced settings</h1>
+
         {!disabled && (
           <p className="mb-6 rounded-lg  border bg-warning-50 px-3 py-2 text-sm text-warning-700">
             Defaults are set to allow automatic proposal execution therefore

--- a/src/components/AdvancedSettingsModal.tsx
+++ b/src/components/AdvancedSettingsModal.tsx
@@ -20,7 +20,7 @@ import { type OgDeployerConfig } from "@/types";
 import { useState, type FormEventHandler, useEffect } from "react";
 import { useImmer, type Updater } from "use-immer";
 import { useLoadOgDeployerConfig } from "@/hooks";
-import { StandardConfigWarning } from "./StandardConfigWarning";
+import { StandardConfigFormWarning } from "./StandardConfigWarning";
 
 type Props = {
   config: OgDeployerConfig;
@@ -157,7 +157,7 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
     <Modal {...props}>
       <div className="max-w-[520px] p-6">
         <h1 className="mb-4 text-lg font-semibold">Advanced settings</h1>
-        <StandardConfigWarning isStandard={configIsStandard} />
+        <StandardConfigFormWarning isStandard={configIsStandard} />
         <Heading>Snapshot Space URL</Heading>
         <p className="mb-6 rounded-lg border border-gray-300 bg-white px-3 py-2 opacity-50 shadow-xs">
           {props.config.spaceUrl}

--- a/src/components/AdvancedSettingsModal.tsx
+++ b/src/components/AdvancedSettingsModal.tsx
@@ -20,6 +20,7 @@ import { type OgDeployerConfig } from "@/types";
 import { useState, type FormEventHandler, useEffect } from "react";
 import { useImmer, type Updater } from "use-immer";
 import { useLoadOgDeployerConfig } from "@/hooks";
+import { StandardConfigWarning } from "./StandardConfigWarning";
 
 type Props = {
   config: OgDeployerConfig;
@@ -142,18 +143,27 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
     props.closeModal();
   };
 
-  // TODO: show auto execution warning
+  /**
+   * Use this to check the form for auto execution
+   */
+  const configIsStandard = (() => {
+    const isWeth = collateralCurrency.value === "WETH";
+    const isCorrectAmount = bondInputProps.value === "2";
+
+    return isWeth && isCorrectAmount;
+  })();
+
   return (
     <Modal {...props}>
       <div className="max-w-[520px] p-6">
         <h1 className="mb-4 text-lg font-semibold">Advanced settings</h1>
-
-        {!disabled && (
+        <StandardConfigWarning isStandard={configIsStandard} />
+        {/* {!disabled && (
           <p className="mb-6 rounded-lg  border bg-warning-50 px-3 py-2 text-sm text-warning-700">
             Defaults are set to allow automatic proposal execution therefore
             these settings should be adjusted with caution!
           </p>
-        )}
+        )} */}
         <Heading>Snapshot Space URL</Heading>
         <p className="mb-6 rounded-lg border border-gray-300 bg-white px-3 py-2 opacity-50 shadow-xs">
           {props.config.spaceUrl}

--- a/src/components/OsnapCard.tsx
+++ b/src/components/OsnapCard.tsx
@@ -20,8 +20,8 @@ export function useOsnapCard() {
   const spaceUrl = searchParams.get("spaceUrl") ?? undefined;
 
   const [loaded, setLoaded] = useState(false);
-  const { enabled } = useOgState();
-  const isActive = enabled.data ?? false;
+  const ogState = useOgState();
+  const isActive = ogState.enabled.data ?? false;
 
   const { config, setConfig, deploy, isDeploying } = useOgDeployer({
     spaceUrl,

--- a/src/components/OsnapCard.tsx
+++ b/src/components/OsnapCard.tsx
@@ -8,12 +8,15 @@ import {
   useOgState,
   useOgDisabler,
   useLoadOgDeployerConfig,
+  useIsStandardConfig,
 } from "@/hooks/OptimisticGovernor";
 import Link from "next/link";
 import {
   AdvancedSettingsModal,
   useAdvancedSettingsModal,
 } from "./AdvancedSettingsModal";
+import { StandardConfigCardWarning } from "./StandardConfigWarning";
+
 export function useOsnapCard() {
   const searchParams = useSearchParams();
   const spaceName = searchParams.get("spaceName") ?? undefined;
@@ -21,6 +24,7 @@ export function useOsnapCard() {
 
   const [loaded, setLoaded] = useState(false);
   const ogState = useOgState();
+  const configState = useIsStandardConfig(ogState);
   const isActive = ogState.enabled.data ?? false;
 
   const { config, setConfig, deploy, isDeploying } = useOgDeployer({
@@ -74,6 +78,7 @@ export function useOsnapCard() {
     errors: [],
     isDisabling,
     isDeploying,
+    configState,
   };
 }
 
@@ -89,6 +94,7 @@ export function OsnapCard() {
     disable,
     isDisabling,
     isDeploying,
+    configState,
   } = useOsnapCard();
 
   const noSpaceCardContent = (
@@ -171,6 +177,7 @@ export function OsnapCard() {
         Propel your DAO into the future with instant, secure and trustless
         execution.
       </h1>
+      <StandardConfigCardWarning configState={configState} />
       <div className="rounded-xl border border-gray-200">
         {cardContent}
         <div className="rounded-b-xl bg-gray-50 px-6 py-4">

--- a/src/components/StandardConfigWarning.tsx
+++ b/src/components/StandardConfigWarning.tsx
@@ -1,8 +1,10 @@
+import { useIsStandardConfig } from "@/hooks/OptimisticGovernor";
+
 type Props = {
   isStandard: boolean;
 };
 
-export const StandardConfigWarning = ({ isStandard }: Props) => {
+export const StandardConfigFormWarning = ({ isStandard }: Props) => {
   if (isStandard) {
     return (
       <div className="mb-6 rounded-lg  border bg-success-50 px-3 py-2 text-sm text-success-700">
@@ -23,6 +25,45 @@ export const StandardConfigWarning = ({ isStandard }: Props) => {
         request transaction execution and post a bond to the UMA Optimistic
         Oracle for verification.
       </p>
+    </div>
+  );
+};
+
+export const StandardConfigCardWarning = ({
+  configState,
+}: {
+  configState: ReturnType<typeof useIsStandardConfig>;
+}) => {
+  if (!configState) {
+    return;
+  }
+
+  if (configState.automaticExecution) {
+    return <StandardConfigFormWarning isStandard />;
+  }
+
+  return (
+    <div className="mb-6 flex flex-col gap-2 rounded-lg  border bg-warning-50 px-3 py-2 text-sm text-warning-700">
+      <p>
+        Warning! You are <strong>not</strong> using the default settings. If
+        your proposal passes, you will be required to <strong>manually</strong>{" "}
+        request transaction execution and post a bond to the UMA Optimistic
+        Oracle for verification.
+      </p>
+      <p>
+        Settings that are <strong>Non standard:</strong>{" "}
+      </p>
+      <ul className="pl-4 [&>li]:list-disc">
+        {!configState.bondAmount && <li>Bond Amount (Should be 2)</li>}
+        {!configState.bondToken && <li>Bond Token (Should be WETH)</li>}
+        {!configState.rules && (
+          <li>
+            Space URL (only snapshot.org <strong>production</strong> spaces are
+            supported with automated execution. There is no bot support for
+            testnets.)
+          </li>
+        )}
+      </ul>
     </div>
   );
 };

--- a/src/components/StandardConfigWarning.tsx
+++ b/src/components/StandardConfigWarning.tsx
@@ -1,0 +1,24 @@
+type Props = {
+  isStandard: boolean;
+};
+
+export const StandardConfigWarning = ({ isStandard }: Props) => {
+  return (
+    <div className="mb-6 rounded-lg  border bg-warning-50 px-3 py-2 text-sm text-warning-700">
+      {isStandard ? (
+        <p>
+          Warning! You are using the default settings. If your proposal passes,
+          your transaction will be <strong>automatically executed</strong> and
+          verified by the UMA Optimistic Oracle.
+        </p>
+      ) : (
+        <p>
+          Warning! You are <strong>not</strong> using the default settings. If
+          your proposal passes, you will be required to{" "}
+          <strong>manually</strong> request transaction execution and post a
+          bond to the UMA Optimistic Oracle for verification.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/components/StandardConfigWarning.tsx
+++ b/src/components/StandardConfigWarning.tsx
@@ -3,22 +3,26 @@ type Props = {
 };
 
 export const StandardConfigWarning = ({ isStandard }: Props) => {
-  return (
-    <div className="mb-6 rounded-lg  border bg-warning-50 px-3 py-2 text-sm text-warning-700">
-      {isStandard ? (
+  if (isStandard) {
+    return (
+      <div className="mb-6 rounded-lg  border bg-success-50 px-3 py-2 text-sm text-success-700">
         <p>
           Warning! You are using the default settings. If your proposal passes,
           your transaction will be <strong>automatically executed</strong> and
           verified by the UMA Optimistic Oracle.
         </p>
-      ) : (
-        <p>
-          Warning! You are <strong>not</strong> using the default settings. If
-          your proposal passes, you will be required to{" "}
-          <strong>manually</strong> request transaction execution and post a
-          bond to the UMA Optimistic Oracle for verification.
-        </p>
-      )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6 rounded-lg  border bg-warning-50 px-3 py-2 text-sm text-warning-700">
+      <p>
+        Warning! You are <strong>not</strong> using the default settings. If
+        your proposal passes, you will be required to <strong>manually</strong>{" "}
+        request transaction execution and post a bond to the UMA Optimistic
+        Oracle for verification.
+      </p>
     </div>
   );
 };

--- a/src/hooks/OptimisticGovernor.ts
+++ b/src/hooks/OptimisticGovernor.ts
@@ -32,10 +32,7 @@ import {
   publicClientToProvider,
 } from "../libs";
 import { Defaults, getSnapshotDefaultVotingParameters } from "@/libs/snapshot";
-import {
-  SpaceConfigResponse,
-  isConfigStandard,
-} from "@/app/api/space-config/utils";
+import { SpaceConfigResponse } from "@/app/api/space-config/utils";
 
 export function ogDeployerConfigDefaults(
   config?: Partial<OgDeployerConfig>,
@@ -82,30 +79,11 @@ type ConfigReturnType = {
   error?: Error;
 };
 
-const useIsStandardConfig = (
-  ogState: ReturnType<typeof useOgState>,
-): SpaceConfigResponse | undefined => {
-  const { rules, bond, collateralInfo, chain } = ogState;
-  const isStandard = useMemo(() => {
-    if (rules.data && bond.data && collateralInfo.data && chain) {
-      return isConfigStandard({
-        rules: rules.data,
-        bondAmount: bond.data,
-        collateral: collateralInfo.data.address,
-        chainId: chain.id,
-      });
-    }
-  }, [bond.data, chain, collateralInfo.data, rules.data]);
-
-  return isStandard;
-};
-
 export function useLoadOgDeployerConfig(params: {
   spaceUrl?: string;
 }): ConfigReturnType {
   const spaceDefaults = useSpaceDefaultVotingParameters(params.spaceUrl);
   const ogState = useOgState();
-  const isStandard = useIsStandardConfig(ogState);
 
   return useMemo(() => {
     if (!params.spaceUrl) {
@@ -141,17 +119,14 @@ export function useLoadOgDeployerConfig(params: {
       );
       return {
         isLoading: false,
-        data: {
-          ...ogDeployerConfigDefaults({
-            bondAmount,
-            collateralCurrency: ogState.collateralInfo.data.name,
-            quorum: ruleParams.quorum,
-            votingPeriodHours: ruleParams.votingPeriodHours,
-            challengePeriod: findChallengePeriod(ogState.liveness.data),
-            spaceUrl: params.spaceUrl,
-          }),
-          isStandard,
-        },
+        data: ogDeployerConfigDefaults({
+          bondAmount,
+          collateralCurrency: ogState.collateralInfo.data.name,
+          quorum: ruleParams.quorum,
+          votingPeriodHours: ruleParams.votingPeriodHours,
+          challengePeriod: findChallengePeriod(ogState.liveness.data),
+          spaceUrl: params.spaceUrl,
+        }),
       };
     }
     if (!ogState.enabled.data && spaceDefaults.data) {
@@ -167,7 +142,7 @@ export function useLoadOgDeployerConfig(params: {
     return {
       isLoading: true,
     };
-  }, [spaceDefaults, ogState, params.spaceUrl, isStandard]);
+  }, [spaceDefaults, ogState, params.spaceUrl]);
 }
 export function useOgDeployer(initialConfig?: Partial<OgDeployerConfig>) {
   const { chain } = useNetwork();

--- a/src/hooks/OptimisticGovernor.ts
+++ b/src/hooks/OptimisticGovernor.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import useSWR from "swr";
+import useSwr from "swr";
 import { TransactionStatus } from "@gnosis.pm/safe-apps-sdk";
 import { Address, useAccount, useNetwork, usePublicClient } from "wagmi";
 import { useMemo, useState } from "react";
@@ -48,7 +48,7 @@ export function ogDeployerConfigDefaults(
 }
 export function useSpaceDefaultVotingParameters(spaceUrl?: string) {
   // fetch default space settings from snapshot space
-  return useSWR<Defaults>(
+  return useSwr<Defaults>(
     spaceUrl ?? null,
     getSnapshotDefaultVotingParameters,
     {
@@ -68,7 +68,7 @@ export function useSpaceConfig(
     chainId && safeAddress
       ? `/api/space-config?chainId=${chainId}&address=${safeAddress}`
       : null;
-  return useSWR<SpaceConfigResponse, unknown>(url, (url: string) =>
+  return useSwr<SpaceConfigResponse, unknown>(url, (url: string) =>
     fetch(url).then(async (res) => (await res.json()) as SpaceConfigResponse),
   );
 }
@@ -227,17 +227,17 @@ export function useOgState() {
   const { chain } = useNetwork();
   const { address } = useAccount();
 
-  const enabled = useSWR(`/enabled/${address}/${chain?.id}`, () => {
+  const enabled = useSwr(`/enabled/${address}/${chain?.id}`, () => {
     assert(chain?.id, "Requires chainid");
     assert(address, "Requires safe address");
     return SubgraphClient(chain.id).isEnabled(address);
   });
-  const moduleAddress = useSWR(`/moduleAddress/${address}/${chain?.id}`, () => {
+  const moduleAddress = useSwr(`/moduleAddress/${address}/${chain?.id}`, () => {
     assert(chain?.id, "Requires chainid");
     assert(address, "Requires safe address");
     return SubgraphClient(chain.id).getModuleAddress(address);
   });
-  const collateralInfo = useSWR(
+  const collateralInfo = useSwr(
     `/collateral/${moduleAddress.data}/${chain?.id}`,
     async () => {
       assert(chain?.id, "Requires chainid");
@@ -274,7 +274,7 @@ export function useOgState() {
       return result;
     },
   );
-  const liveness = useSWR(
+  const liveness = useSwr(
     `/liveness/${moduleAddress.data}/${chain?.id}`,
     async () => {
       assert(chain?.id, "Requires chainid");
@@ -291,7 +291,7 @@ export function useOgState() {
       return liveness.toString();
     },
   );
-  const bond = useSWR(
+  const bond = useSwr(
     `/bondAmount/${moduleAddress.data}/${chain?.id}`,
     async () => {
       assert(chain?.id, "Requires chainid");
@@ -308,7 +308,7 @@ export function useOgState() {
       return bondAmount;
     },
   );
-  const rules = useSWR(
+  const rules = useSwr(
     `/rules/${moduleAddress.data}/${chain?.id}`,
     async () => {
       assert(chain?.id, "Requires chainid");
@@ -325,7 +325,7 @@ export function useOgState() {
       return rules;
     },
   );
-  const optimisticOracleV3Address = useSWR(
+  const optimisticOracleV3Address = useSwr(
     `/optimisticOracleV3Address/${moduleAddress.data}/${chain?.id}`,
     async () => {
       assert(chain?.id, "Requires chainid");

--- a/src/libs/contracts.ts
+++ b/src/libs/contracts.ts
@@ -7,7 +7,8 @@ import {
   polygon,
   arbitrum,
   avalanche,
-} from "@wagmi/chains";
+  Chain,
+} from "viem/chains";
 import { type Address } from "wagmi";
 
 export { Address };
@@ -19,6 +20,7 @@ export function isAddress(addr: unknown): addr is Address {
 export type ContractData = {
   name: string;
   chainId: number;
+  network: Chain;
   address: Address;
   deployBlockNumber?: number;
   subgraph?: string;
@@ -35,6 +37,7 @@ export const contractDataList: ContractData[] = [
   {
     // mainnet
     chainId: mainnet.id,
+    network: mainnet,
     name: "OptimisticGovernor",
     address: "0x28CeBFE94a03DbCA9d17143e9d2Bd1155DC26D5d",
     subgraph:
@@ -44,6 +47,7 @@ export const contractDataList: ContractData[] = [
   {
     //goerli
     chainId: goerli.id,
+    network: goerli,
     name: "OptimisticGovernor",
     address: "0x07a7Be7AA4AaD42696A17e974486cb64A4daC47b",
     deployBlockNumber: 8700589,
@@ -53,6 +57,7 @@ export const contractDataList: ContractData[] = [
   {
     // optimism
     chainId: optimism.id,
+    network: optimism,
     name: "OptimisticGovernor",
     address: "0x357fe84E438B3150d2F68AB9167bdb8f881f3b9A",
     subgraph:
@@ -61,6 +66,7 @@ export const contractDataList: ContractData[] = [
   {
     // gnosis
     chainId: gnosis.id,
+    network: gnosis,
     name: "OptimisticGovernor",
     subgraph:
       "https://api.thegraph.com/subgraphs/name/umaprotocol/gnosis-optimistic-governor",
@@ -69,6 +75,7 @@ export const contractDataList: ContractData[] = [
   {
     // polygon
     chainId: polygon.id,
+    network: polygon,
     name: "OptimisticGovernor",
     address: "0x3Cc4b597E9c3f51288c6Cd0c087DC14c3FfdD966",
     subgraph:
@@ -77,6 +84,7 @@ export const contractDataList: ContractData[] = [
   {
     // arbitrum
     chainId: arbitrum.id,
+    network: arbitrum,
     name: "OptimisticGovernor",
     address: "0x30679ca4ea452d3df8a6c255a806e08810321763",
     subgraph:
@@ -85,6 +93,7 @@ export const contractDataList: ContractData[] = [
   {
     // avalanche
     chainId: avalanche.id,
+    network: avalanche,
     name: "OptimisticGovernor",
     address: "0xEF8b46765ae805537053C59f826C3aD61924Db45",
     subgraph:
@@ -94,6 +103,7 @@ export const contractDataList: ContractData[] = [
   {
     // mainnet https://github.com/UMAprotocol/subgraphs/blob/master/packages/optimistic-oracle-v3/manifest/data/mainnet.json
     chainId: mainnet.id,
+    network: mainnet,
     name: "OptimisticOracleV3",
     address: "0xfb55F43fB9F48F63f9269DB7Dde3BbBe1ebDC0dE",
     deployBlockNumber: 16636058,
@@ -101,6 +111,7 @@ export const contractDataList: ContractData[] = [
   {
     //goerli https://github.com/UMAprotocol/subgraphs/blob/master/packages/optimistic-oracle-v3/manifest/data/goerli.json
     chainId: goerli.id,
+    network: goerli,
     name: "OptimisticOracleV3",
     address: "0x9923D42eF695B5dd9911D05Ac944d4cAca3c4EAB",
     deployBlockNumber: 8497481,
@@ -108,6 +119,7 @@ export const contractDataList: ContractData[] = [
   {
     // optimism https://github.com/UMAprotocol/subgraphs/blob/master/packages/optimistic-oracle-v3/manifest/data/optimism.json
     chainId: optimism.id,
+    network: optimism,
     name: "OptimisticOracleV3",
     address: "0x072819Bb43B50E7A251c64411e7aA362ce82803B",
     deployBlockNumber: 74537234,
@@ -115,6 +127,7 @@ export const contractDataList: ContractData[] = [
   {
     // gnosis https://github.com/UMAprotocol/subgraphs/blob/master/packages/optimistic-oracle-v3/manifest/data/gnosis.json
     chainId: gnosis.id,
+    network: gnosis,
     name: "OptimisticOracleV3",
     address: "0x22A9AaAC9c3184f68C7B7C95b1300C4B1D2fB95C",
     deployBlockNumber: 27087150,
@@ -122,6 +135,7 @@ export const contractDataList: ContractData[] = [
   {
     // polygon https://github.com/UMAprotocol/subgraphs/blob/master/packages/optimistic-oracle-v3/manifest/data/polygon.json
     chainId: polygon.id,
+    network: polygon,
     name: "OptimisticOracleV3",
     address: "0x5953f2538F613E05bAED8A5AeFa8e6622467AD3D",
     deployBlockNumber: 39331673,
@@ -129,6 +143,7 @@ export const contractDataList: ContractData[] = [
   {
     // arbitrum https://github.com/UMAprotocol/subgraphs/blob/master/packages/optimistic-oracle-v3/manifest/data/arbitrum.json
     chainId: arbitrum.id,
+    network: arbitrum,
     name: "OptimisticOracleV3",
     address: "0xa6147867264374F324524E30C02C331cF28aa879",
     deployBlockNumber: 61236565,
@@ -136,90 +151,105 @@ export const contractDataList: ContractData[] = [
   {
     // avalanche https://github.com/UMAprotocol/subgraphs/blob/master/packages/optimistic-oracle-v3/manifest/data/avalanche.json
     chainId: avalanche.id,
+    network: avalanche,
     name: "OptimisticOracleV3",
     address: "0xa4199d73ae206d49c966cF16c58436851f87d47F",
     deployBlockNumber: 27816737,
   },
   {
     chainId: mainnet.id,
+    network: mainnet,
     name: "USDC",
     address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     decimals: 6,
   },
   {
     chainId: polygon.id,
+    network: polygon,
     name: "USDC",
     address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
     decimals: 6,
   },
   {
     chainId: goerli.id,
+    network: goerli,
     name: "USDC",
     address: "0x07865c6E87B9F70255377e024ace6630C1Eaa37F",
     decimals: 6,
   },
   {
     chainId: gnosis.id,
+    network: gnosis,
     name: "USDC",
     address: "0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83",
     decimals: 6,
   },
   {
     chainId: optimism.id,
+    network: optimism,
     name: "USDC",
     address: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
     decimals: 6,
   },
   {
     chainId: arbitrum.id,
+    network: arbitrum,
     name: "USDC",
     address: "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
     decimals: 6,
   },
   {
     chainId: avalanche.id,
+    network: avalanche,
     name: "USDC",
     address: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
     decimals: 6,
   },
   {
     chainId: mainnet.id,
+    network: mainnet,
     name: "WETH",
     address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     decimals: 18,
   },
   {
     chainId: polygon.id,
+    network: polygon,
     name: "WETH",
     address: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
     decimals: 18,
   },
   {
     chainId: goerli.id,
+    network: goerli,
     name: "WETH",
     address: "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
     decimals: 18,
   },
   {
     chainId: gnosis.id,
+    network: gnosis,
     name: "WETH",
     address: "0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1",
     decimals: 18,
   },
   {
     chainId: optimism.id,
+    network: optimism,
     name: "WETH",
     address: "0x4200000000000000000000000000000000000006",
     decimals: 18,
   },
   {
     chainId: arbitrum.id,
+    network: arbitrum,
     name: "WETH",
     address: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
     decimals: 18,
   },
   {
     chainId: avalanche.id,
+    network: avalanche,
     name: "WETH",
     address: "0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB",
     decimals: 18,

--- a/src/libs/ethersUtils.ts
+++ b/src/libs/ethersUtils.ts
@@ -1,5 +1,7 @@
 import { type PublicClient, type WalletClient } from "wagmi";
 import { providers } from "ethers";
+import { createPublicClient, getContract, http } from "viem";
+import { contractDataList } from ".";
 
 export function publicClientToProvider(publicClient: PublicClient) {
   const { chain, transport } = publicClient;
@@ -20,4 +22,21 @@ export function walletClientToSigner(walletClient: WalletClient) {
   const provider = new providers.Web3Provider(transport, network);
   const signer = provider.getSigner(account.address);
   return signer;
+}
+
+export function getPublicClient(chainId: number) {
+  const networkConfig = contractDataList.find(
+    (chain) => chain.chainId === chainId,
+  );
+
+  if (!networkConfig) {
+    return;
+  }
+  return createPublicClient({
+    // batch: {
+    //   multicall: true,
+    // },
+    chain: networkConfig.network,
+    transport: http(),
+  });
 }

--- a/src/libs/ethersUtils.ts
+++ b/src/libs/ethersUtils.ts
@@ -1,6 +1,6 @@
 import { type PublicClient, type WalletClient } from "wagmi";
 import { providers } from "ethers";
-import { createPublicClient, getContract, http } from "viem";
+import { createPublicClient, http } from "viem";
 import { contractDataList } from ".";
 
 export function publicClientToProvider(publicClient: PublicClient) {
@@ -33,9 +33,9 @@ export function getPublicClient(chainId: number) {
     return;
   }
   return createPublicClient({
-    // batch: {
-    //   multicall: true,
-    // },
+    batch: {
+      multicall: true,
+    },
     chain: networkConfig.network,
     transport: http(),
   });

--- a/src/libs/ogSubgraph.ts
+++ b/src/libs/ogSubgraph.ts
@@ -26,7 +26,7 @@ export function Client(chainId: number) {
     const response = await request<Response>(subgraph, gqlQuery);
     // TODO: might be better to throw with descriptive message here
     if (!response.safe) {
-      throw new Error("No module deployed on this safe");
+      throw new Error("No module deployed on this safe", { cause: 404 });
     }
     return ethers.utils.getAddress(response.safe.optimisticGovernor.id);
   }

--- a/src/libs/ogSubgraph.ts
+++ b/src/libs/ogSubgraph.ts
@@ -8,9 +8,11 @@ export function Client(chainId: number) {
   assert(ogInfo.subgraph, `No subgraph defined for OG on chainId ${chainId}`);
   const subgraph = ogInfo.subgraph;
 
-  async function getModuleAddress(safeAddress: string): Promise<string> {
+  async function getModuleAddress(
+    safeAddress: string,
+  ): Promise<string | undefined> {
     type Response = {
-      safe: { optimisticGovernor: { id: string } };
+      safe: { optimisticGovernor: { id: string } } | null;
     };
     const gqlQuery = gql`
       query getModuleAddress {
@@ -22,11 +24,15 @@ export function Client(chainId: number) {
       }
     `;
     const response = await request<Response>(subgraph, gqlQuery);
+    // TODO: might be better to throw with descriptive message here
+    if (!response.safe) {
+      throw new Error("No module deployed on this safe");
+    }
     return ethers.utils.getAddress(response.safe.optimisticGovernor.id);
   }
-  async function isEnabled(safeAddress: string): Promise<boolean> {
+  async function isEnabled(safeAddress: string): Promise<boolean | undefined> {
     type Response = {
-      safe: { isOptimisticGovernorEnabled: boolean };
+      safe: { isOptimisticGovernorEnabled: boolean } | null;
     };
     const gqlQuery = gql`
       query isOSnapEnabled {
@@ -36,6 +42,9 @@ export function Client(chainId: number) {
       }
     `;
     const response = await request<Response>(subgraph, gqlQuery);
+    if (!response.safe) {
+      return undefined;
+    }
     return response.safe.isOptimisticGovernorEnabled;
   }
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,3 +1,4 @@
+import { SpaceConfigResponse } from "@/app/api/space-config/utils";
 import { ChallengePeriod } from "@/constants/challengePeriods";
 import { Currency } from "@/constants/currencies";
 
@@ -9,4 +10,5 @@ export type OgDeployerConfig = {
   quorum: string; // voting quorum
   votingPeriodHours: string; // minimum voting period in integer hours
   rules?: string | undefined;
+  isStandard?: SpaceConfigResponse;
 };

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -1,0 +1,17 @@
+export type ErrorWithMessage = Error & {
+  message: string;
+};
+
+export type HttpError = ErrorWithMessage & {
+  cause: number;
+};
+
+// predicate for better error handling
+export function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+  return error !== null && typeof error === "object" && "message" in error;
+}
+
+// predicate for better error handling in API routes
+export function isHttpError(error: unknown): error is HttpError {
+  return isErrorWithMessage(error) && typeof error.cause === "number";
+}


### PR DESCRIPTION
## motivation

We need to show a warning to users about bot support as it pertains to their osnap settings. 
In the oSnap safe app, this is relatively straight forward, we just do some validation on the form and show relevant warning messages. We also want to show a warning for users in Snapshot. 

## Work done 
1. Implement some logic in the settings modal form to show relevant warning message. This is **only** checking bond amount and bond currency. This is checking the settings **before** you actually store them.
2. Implement a serverless function which checks your settings stored on chain, **after** you've saved them and deployed your module. We can use this outside of the safe app, in snapshot for example. This endpoint checks bond amount, bond currency, but also **rules**. 

## screenshots

![Screenshot 2024-02-16 at 14 49 30](https://github.com/UMAprotocol/osnap-safe-app/assets/51655063/3db922a5-b2ef-4a9a-97f7-350338090195)
![Screenshot 2024-02-16 at 14 49 42](https://github.com/UMAprotocol/osnap-safe-app/assets/51655063/c8a27dc3-1c6e-4128-b227-c9e75bdc0a0f)
