### PR TITLE
fix: only show warning if safe is enabled, fix bond comparison

### DIFF
--- a/src/components/AdvancedSettingsModal.tsx
+++ b/src/components/AdvancedSettingsModal.tsx
@@ -148,7 +148,13 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
    */
   const configIsStandard = (() => {
     const isWeth = collateralCurrency.value === "WETH";
-    const isCorrectAmount = bondInputProps.value === "2";
+    let isCorrectAmount = false;
+    try {
+      isCorrectAmount = Number(bondInputProps.value) === 2;
+    } catch (err) {
+      console.warn("Error parsing bondInputProps as a number:", err);
+      isCorrectAmount = false;
+    }
 
     return isWeth && isCorrectAmount;
   })();

--- a/src/components/OsnapCard.tsx
+++ b/src/components/OsnapCard.tsx
@@ -183,7 +183,7 @@ export function OsnapCard() {
         Propel your DAO into the future with instant, secure and trustless
         execution.
       </h1>
-      <StandardConfigCardWarning configState={configState} />
+      {isActive && <StandardConfigCardWarning configState={configState} />}
       <div className="rounded-xl border border-gray-200">
         {cardContent}
         <div className="rounded-b-xl bg-gray-50 px-6 py-4">

--- a/src/components/StandardConfigWarning.tsx
+++ b/src/components/StandardConfigWarning.tsx
@@ -9,8 +9,8 @@ export const StandardConfigFormWarning = ({ isStandard }: Props) => {
     return (
       <div className="mb-6 rounded-lg  border bg-success-50 px-3 py-2 text-sm text-success-700">
         <p>
-          Warning! You are using the default settings. If your proposal passes,
-          your transaction will be <strong>automatically executed</strong> and
+          You are using the default settings. If your proposal passes, your
+          transaction will be <strong>automatically executed</strong> and
           verified by the UMA Optimistic Oracle.
         </p>
       </div>


### PR DESCRIPTION
## motivation
noticed some weird behavior with warnings
1. if osnap wasnt enabled, warning would show 
2. warning would show incorrectly execution was disabled when it actually wasnt
3. if execution was enabled we would say "warning" but it didnt seem right as a warning

## changes
fixed minor things about how this shows, will comment code