### PR TITLE
fix: migrate to subgraph studio

### DIFF
--- a/src/libs/contracts.ts
+++ b/src/libs/contracts.ts
@@ -14,7 +14,7 @@ import {
 import { type Address } from "wagmi";
 import { coreDao } from "../app/customChains";
 
-import { studioApiKey } from "./env";
+import { graphStudioApiKey } from "./env";
 
 export { Address };
 
@@ -46,7 +46,7 @@ export const contractDataList: ContractData[] = [
     network: mainnet,
     name: "OptimisticGovernor",
     address: "0x28CeBFE94a03DbCA9d17143e9d2Bd1155DC26D5d",
-    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/DQpwhiRSPQJEuc8y6ZBGsFfNpfwFQ8NjmjLmfv8kBkLu`,
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${graphStudioApiKey}/subgraphs/id/DQpwhiRSPQJEuc8y6ZBGsFfNpfwFQ8NjmjLmfv8kBkLu`,
     deployBlockNumber: 16890621,
   },
   {
@@ -65,14 +65,14 @@ export const contractDataList: ContractData[] = [
     network: optimism,
     name: "OptimisticGovernor",
     address: "0x357fe84E438B3150d2F68AB9167bdb8f881f3b9A",
-    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/Fd5RvSfkajAJ8Mi9sPxFSMVPFf56SDivDQW3ocqTAW5`,
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${graphStudioApiKey}/subgraphs/id/Fd5RvSfkajAJ8Mi9sPxFSMVPFf56SDivDQW3ocqTAW5`,
   },
   {
     // gnosis
     chainId: gnosis.id,
     network: gnosis,
     name: "OptimisticGovernor",
-    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/RrkjZ6wTgLJkcjX68auzrEZHMRYwDx8kR5sFQQy4Phz`,
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${graphStudioApiKey}/subgraphs/id/RrkjZ6wTgLJkcjX68auzrEZHMRYwDx8kR5sFQQy4Phz`,
     address: "0x972396Ab668cd11dc1F6321A5ae30c6A8d3759F0",
   },
   {
@@ -81,7 +81,7 @@ export const contractDataList: ContractData[] = [
     network: polygon,
     name: "OptimisticGovernor",
     address: "0x3Cc4b597E9c3f51288c6Cd0c087DC14c3FfdD966",
-    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/7L2JM14PnZgxGnRX7xaz54zWS6KVK6ZqVRCxEKJrJTDG`,
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${graphStudioApiKey}/subgraphs/id/7L2JM14PnZgxGnRX7xaz54zWS6KVK6ZqVRCxEKJrJTDG`,
   },
   {
     // arbitrum
@@ -89,7 +89,7 @@ export const contractDataList: ContractData[] = [
     network: arbitrum,
     name: "OptimisticGovernor",
     address: "0x30679ca4ea452d3df8a6c255a806e08810321763",
-    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/BfK867bnkQhnx1LspA99ypqiqxbAReQ92aZz66Ubv4tz`,
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${graphStudioApiKey}/subgraphs/id/BfK867bnkQhnx1LspA99ypqiqxbAReQ92aZz66Ubv4tz`,
   },
   {
     // avalanche
@@ -97,7 +97,7 @@ export const contractDataList: ContractData[] = [
     network: avalanche,
     name: "OptimisticGovernor",
     address: "0xEF8b46765ae805537053C59f826C3aD61924Db45",
-    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/5F8875fmvtnv8Vv4aeedUcwNWjuxUg54aTHdapFuMJi3`,
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${graphStudioApiKey}/subgraphs/id/5F8875fmvtnv8Vv4aeedUcwNWjuxUg54aTHdapFuMJi3`,
   },
   {
     // core
@@ -115,7 +115,7 @@ export const contractDataList: ContractData[] = [
     name: "OptimisticGovernor",
     address: "0x40153DdFAd90C49dbE3F5c9F96f2a5B25ec67461",
     deployBlockNumber: 5421242,
-    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/5pwrjCkpcpCd79k9MBS5yVgnsHQiw6afvXUfzqHjdRFw`,
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${graphStudioApiKey}/subgraphs/id/5pwrjCkpcpCd79k9MBS5yVgnsHQiw6afvXUfzqHjdRFw`,
   },
   // optimistic oracle v3
   {

--- a/src/libs/contracts.ts
+++ b/src/libs/contracts.ts
@@ -14,6 +14,8 @@ import {
 import { type Address } from "wagmi";
 import { coreDao } from "../app/customChains";
 
+import { studioApiKey } from ".";
+
 export { Address };
 export function isAddress(addr: unknown): addr is Address {
   return typeof addr === "string" && addr.startsWith("0x");
@@ -43,8 +45,7 @@ export const contractDataList: ContractData[] = [
     network: mainnet,
     name: "OptimisticGovernor",
     address: "0x28CeBFE94a03DbCA9d17143e9d2Bd1155DC26D5d",
-    subgraph:
-      "https://api.thegraph.com/subgraphs/name/umaprotocol/mainnet-optimistic-governor",
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/DQpwhiRSPQJEuc8y6ZBGsFfNpfwFQ8NjmjLmfv8kBkLu`,
     deployBlockNumber: 16890621,
   },
   {

--- a/src/libs/contracts.ts
+++ b/src/libs/contracts.ts
@@ -65,16 +65,14 @@ export const contractDataList: ContractData[] = [
     network: optimism,
     name: "OptimisticGovernor",
     address: "0x357fe84E438B3150d2F68AB9167bdb8f881f3b9A",
-    subgraph:
-      "https://api.thegraph.com/subgraphs/name/umaprotocol/optimism-optimistic-governor",
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/Fd5RvSfkajAJ8Mi9sPxFSMVPFf56SDivDQW3ocqTAW5`,
   },
   {
     // gnosis
     chainId: gnosis.id,
     network: gnosis,
     name: "OptimisticGovernor",
-    subgraph:
-      "https://api.thegraph.com/subgraphs/name/umaprotocol/gnosis-optimistic-governor",
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/RrkjZ6wTgLJkcjX68auzrEZHMRYwDx8kR5sFQQy4Phz`,
     address: "0x972396Ab668cd11dc1F6321A5ae30c6A8d3759F0",
   },
   {
@@ -83,8 +81,7 @@ export const contractDataList: ContractData[] = [
     network: polygon,
     name: "OptimisticGovernor",
     address: "0x3Cc4b597E9c3f51288c6Cd0c087DC14c3FfdD966",
-    subgraph:
-      "https://api.thegraph.com/subgraphs/name/umaprotocol/polygon-optimistic-governor",
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/7L2JM14PnZgxGnRX7xaz54zWS6KVK6ZqVRCxEKJrJTDG`,
   },
   {
     // arbitrum
@@ -92,8 +89,7 @@ export const contractDataList: ContractData[] = [
     network: arbitrum,
     name: "OptimisticGovernor",
     address: "0x30679ca4ea452d3df8a6c255a806e08810321763",
-    subgraph:
-      "https://api.thegraph.com/subgraphs/name/umaprotocol/arbitrum-optimistic-governor",
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/BfK867bnkQhnx1LspA99ypqiqxbAReQ92aZz66Ubv4tz`,
   },
   {
     // avalanche
@@ -101,8 +97,7 @@ export const contractDataList: ContractData[] = [
     network: avalanche,
     name: "OptimisticGovernor",
     address: "0xEF8b46765ae805537053C59f826C3aD61924Db45",
-    subgraph:
-      "https://api.thegraph.com/subgraphs/name/umaprotocol/avalanche-optimistic-governor",
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/5F8875fmvtnv8Vv4aeedUcwNWjuxUg54aTHdapFuMJi3`,
   },
   {
     // core
@@ -120,8 +115,7 @@ export const contractDataList: ContractData[] = [
     name: "OptimisticGovernor",
     address: "0x40153DdFAd90C49dbE3F5c9F96f2a5B25ec67461",
     deployBlockNumber: 5421242,
-    subgraph:
-      "https://api.thegraph.com/subgraphs/name/reinis-frp/sepolia-optimistic-governor",
+    subgraph: `https://gateway-arbitrum.network.thegraph.com/api/${studioApiKey}/subgraphs/id/5pwrjCkpcpCd79k9MBS5yVgnsHQiw6afvXUfzqHjdRFw`,
   },
   // optimistic oracle v3
   {

--- a/src/libs/contracts.ts
+++ b/src/libs/contracts.ts
@@ -14,9 +14,10 @@ import {
 import { type Address } from "wagmi";
 import { coreDao } from "../app/customChains";
 
-import { studioApiKey } from ".";
+import { studioApiKey } from "./env";
 
 export { Address };
+
 export function isAddress(addr: unknown): addr is Address {
   return typeof addr === "string" && addr.startsWith("0x");
 }

--- a/src/libs/env.ts
+++ b/src/libs/env.ts
@@ -1,6 +1,6 @@
-export const studioApiKey = (() => {
-  const studioApiKey = process.env.NEXT_PUBLIC_STUDIO_API_KEY;
-  if (studioApiKey === undefined)
+export const graphStudioApiKey = (() => {
+  const graphStudioApiKey = process.env.NEXT_PUBLIC_GRAPH_STUDIO_API_KEY;
+  if (graphStudioApiKey === undefined)
     throw new Error("Subgraph Studio API key missing!");
-  return studioApiKey;
+  return graphStudioApiKey;
 })();

--- a/src/libs/env.ts
+++ b/src/libs/env.ts
@@ -1,8 +1,6 @@
-function getStudioApiKey() {
+export const studioApiKey = (() => {
   const studioApiKey = process.env.NEXT_PUBLIC_STUDIO_API_KEY;
   if (studioApiKey === undefined)
     throw new Error("Subgraph Studio API key missing!");
   return studioApiKey;
-}
-
-export const studioApiKey = getStudioApiKey();
+})();

--- a/src/libs/env.ts
+++ b/src/libs/env.ts
@@ -1,0 +1,8 @@
+function getStudioApiKey() {
+  const studioApiKey = process.env.NEXT_PUBLIC_STUDIO_API_KEY;
+  if (studioApiKey === undefined)
+    throw new Error("Subgraph Studio API key missing!");
+  return studioApiKey;
+}
+
+export const studioApiKey = getStudioApiKey();

--- a/src/libs/index.ts
+++ b/src/libs/index.ts
@@ -2,3 +2,4 @@ export * from "./contracts";
 export * from "./ogUtils";
 export * from "./ethersUtils";
 export * from "./abis";
+export * from "./env";


### PR DESCRIPTION
With the deprecation of hosted subgraph service we need to migrate to Subgraph Studio

Fixes: https://linear.app/uma/issue/UMA-2639/subgraph-studio-in-osnap-safe-app