### PR TITLE
feat: add form validation for minimum bond amount

### DIFF
--- a/src/components/AdvancedSettingsModal.tsx
+++ b/src/components/AdvancedSettingsModal.tsx
@@ -70,7 +70,6 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
     tokenSymbol: "USDC",
   });
 
-  // as bigint
   const minimumBondAmount = (() => {
     if (collateralCurrency.value === "USDC") {
       return minBondUsdc ? Number(formatUnits(minBondUsdc, 6)) : 0;
@@ -95,6 +94,7 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
     ).toString(),
     required: true,
   });
+
   const votingPeriodInputProps = useNumberInput({
     label: "Voting Period hours",
     initialValue: props.config.votingPeriodHours,
@@ -104,6 +104,7 @@ export function AdvancedSettingsModal(props: AdvancedSettingsModalProps) {
     ),
     placeholder: parseInt(props.config.votingPeriodHours).toString(),
     required: true,
+    positiveOnly: true,
   });
 
   // we have data that loads from snapshot and on chain, so we need to update our inputs when this comes in.

--- a/src/components/NumberInput.tsx
+++ b/src/components/NumberInput.tsx
@@ -45,11 +45,26 @@ export function useNumberInput(props: Props) {
     [onChangeProp],
   );
 
+  const error = (() => {
+    if (props.validate && !props.validate(value)) {
+      return "Invalid input"; // generic error message
+    }
+    if (props.required && !value) {
+      return "Required";
+    }
+    if (props.min && Number(value) < props.min) {
+      return `Minimum value: ${props.min}`;
+    }
+  })();
+
   function isValid() {
     if (props.required && dirty && value === "") {
       return false;
     }
     if (props.validate && !props.validate(value)) {
+      return false;
+    }
+    if (props.min && Number(value) < props.min) {
       return false;
     }
     return true;
@@ -67,6 +82,7 @@ export function useNumberInput(props: Props) {
       min,
       disabled,
       setValue,
+      error,
     }),
     [
       props,
@@ -79,6 +95,7 @@ export function useNumberInput(props: Props) {
       min,
       disabled,
       setValue,
+      error,
     ],
   );
 }
@@ -95,7 +112,7 @@ export function NumberInput(props: NumberInputProps) {
     "border-error-200 bg-error-50 text-error-700 placeholder:text-error-500";
   const inputStyle = props.valid ? validStyleInputStyle : invalidInputStyle;
   return (
-    <div>
+    <div className="relative">
       <label
         htmlFor={props.id}
         className={`mb-1 block font-semibold ${labelStyle}`}
@@ -113,6 +130,11 @@ export function NumberInput(props: NumberInputProps) {
         className={`h-11 w-full rounded-lg border px-3 py-2 shadow-xs ${inputStyle} disabled:cursor-not-allowed disabled:opacity-50`}
         disabled={props.disabled}
       />
+      {props.error && (
+        <div className="absolute -bottom-4 left-0 text-xs text-primary-500">
+          {props.error}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/NumberInput.tsx
+++ b/src/components/NumberInput.tsx
@@ -20,6 +20,7 @@ type Props = {
   isWholeNumber?: boolean;
   min?: number;
   disabled?: boolean | undefined;
+  positiveOnly?: boolean;
 };
 
 export function useNumberInput(props: Props) {
@@ -49,6 +50,9 @@ export function useNumberInput(props: Props) {
     if (props.validate && !props.validate(value)) {
       return "Invalid input"; // generic error message
     }
+    if (props.positiveOnly && Number(value) < 0) {
+      return "Positive values only";
+    }
     if (props.required && !value) {
       return "Required";
     }
@@ -59,6 +63,9 @@ export function useNumberInput(props: Props) {
 
   function isValid() {
     if (props.required && dirty && value === "") {
+      return false;
+    }
+    if (props.positiveOnly && Number(value) < 0) {
       return false;
     }
     if (props.validate && !props.validate(value)) {

--- a/src/components/RadioDropdown.tsx
+++ b/src/components/RadioDropdown.tsx
@@ -51,7 +51,7 @@ export function RadioDropdown<
           align="start"
           side="bottom"
           sideOffset={4}
-          className="mt-1 w-[--radix-dropdown-menu-trigger-width] rounded-lg border border-gray-300 bg-white text-gray-900 shadow-xs"
+          className="z-[2] mt-1 w-[--radix-dropdown-menu-trigger-width] rounded-lg border border-gray-300 bg-white text-gray-900 shadow-xs"
         >
           {props.items.map((item) => (
             <DropdownMenu.RadioItem

--- a/src/hooks/useOptimisticOracleV3.ts
+++ b/src/hooks/useOptimisticOracleV3.ts
@@ -1,23 +1,26 @@
 import { filterContracts, OptimisticOracleV3Abi } from "../libs";
-import { useContractRead } from "wagmi";
+import { useContractRead, useNetwork } from "wagmi";
 
-export function useGetMinimumBond(params: {
-  chainId: number;
-  tokenSymbol: string;
-}) {
-  const { chainId, tokenSymbol } = params;
+export function useGetMinimumBond(params: { tokenSymbol: string }) {
+  const { chain } = useNetwork();
+  const { tokenSymbol } = params;
 
   // we use filter since this wont throw error in hooks, but it may return any number of contracts
   const oracleContracts = filterContracts({
-    chainId,
+    chainId: chain?.id,
     name: "OptimisticOracleV3",
   });
-  const tokenContracts = filterContracts({ chainId, name: tokenSymbol });
+
+  const tokenContracts = filterContracts({
+    chainId: chain?.id,
+    name: tokenSymbol,
+  });
   // just take the first contract
   const [oracleContract] = oracleContracts;
   const [tokenContract] = tokenContracts;
 
   return useContractRead({
+    chainId: chain?.id,
     address: oracleContract.address,
     abi: OptimisticOracleV3Abi,
     functionName: "getMinimumBond",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4268,10 +4268,10 @@
     "@typescript-eslint/types" "6.2.1"
     eslint-visitor-keys "^3.4.1"
 
-"@uma/zodiac@^4.0.3":
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/@uma/zodiac/-/zodiac-4.0.3.tgz#e669dcdb3057e63aad7b0da89c70d1d472cb48e3"
-  integrity sha512-hY9RxNqakuLOOVhdYzoowFds+FcOdbpHCZ8wXZPgl/eEcnve1DoHIy4u/kQ5wj9Y547x2XtiyTl7v/SYx1ErPQ==
+"@uma/zodiac@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@uma/zodiac/-/zodiac-4.0.4.tgz#d657d59a076b994bd936e6bb4f0d9c064f90e3f3"
+  integrity sha512-z2zb/Hn7Y7lIh/1+qKAjiPiRVcqdVHAGbb21UDYRwRPgzkXM8/wQJhhea0zav1oBSEBGLKN9PGltXM/P5wmVmw==
   dependencies:
     "@gnosis.pm/mock-contract" "^4.0.0"
     "@gnosis.pm/safe-contracts" "1.3.0"


### PR DESCRIPTION
## motivation

Currently the form in the advanced settings modal lets you input any arbitrary amount as the bond.
In this PR we check the bond amount for WETH and USDC for a given chain and only allow the user to input an amount equal to or greater than the minimum.

