### PR TITLE
feat: allow private infura provider urls

### DIFF
--- a/src/app/api/space-config/route.ts
+++ b/src/app/api/space-config/route.ts
@@ -8,6 +8,7 @@ import {
   parseParams,
 } from "./utils";
 import { Address } from "viem";
+import { getInfuraUrl } from '@/libs/contracts'
 
 /**
  * Check if a space's deployed (on-chain) settings are supported by our bots.
@@ -53,6 +54,7 @@ export async function GET(req: NextRequest) {
     const moduleConfig = await getModuleConfig(
       moduleAddress as Address,
       chainId,
+      getInfuraUrl(chainId,process.env.INFURA_KEY)
     );
 
     const isStandard = isConfigStandard({ ...moduleConfig, chainId });
@@ -67,6 +69,7 @@ export async function GET(req: NextRequest) {
       },
     });
   } catch (error) {
+    console.error('Error getting space deployment',error)
     // catch and rethrow with specific error codes, eg. in validation
     if (isHttpError(error)) {
       return NextResponse.json(

--- a/src/app/api/space-config/utils.ts
+++ b/src/app/api/space-config/utils.ts
@@ -44,8 +44,8 @@ export function parseParams(params: URLSearchParams) {
   };
 }
 
-export async function getModuleConfig(moduleAddress: Address, chainId: number) {
-  const provider = getPublicClient(chainId);
+export async function getModuleConfig(moduleAddress: Address, chainId: number, providerUrl?:string) {
+  const provider = getPublicClient(chainId,providerUrl);
 
   if (!provider) {
     throw new Error("Network not supported");

--- a/src/libs/contracts.ts
+++ b/src/libs/contracts.ts
@@ -34,6 +34,7 @@ export type ContractData = {
   decimals?: number;
 };
 
+
 export const oSnapIdentifier =
   "0x4153534552545f54525554480000000000000000000000000000000000000000";
 // contract addresses pulled from https://github.com/UMAprotocol/protocol/tree/master/packages/core/networks
@@ -377,5 +378,23 @@ export function getTokenAddress(
   return findContract({ chainId, name }).address;
 }
 
+
 // https://github.com/gnosis/zodiac-safe-app/blob/0dfeac33b8e95af566c7ff7b1d77017071219599/packages/app/src/services/helpers.ts#L4C1-L4C71
 export const AddressOne = "0x0000000000000000000000000000000000000001";
+
+export const infuraUrls: Record<number, string> = {
+  1: "https://mainnet.infura.io/v3/",
+  11155111: "https://sepolia.infura.io/v3/",
+  137: "https://polygon-mainnet.infura.io/v3/",
+  10: "https://optimism-mainnet.infura.io/v3/",
+  42161: "https://arbitrum-mainnet.infura.io/v3/",
+  8453: "https://base-mainnet.infura.io/v3/",
+  43114: "https://avalanche-mainnet.infura.io/v3/",
+};
+
+export function getInfuraUrl(chainId: number, apiKey?: string): string | undefined {
+  if(!apiKey) return undefined;
+  const infuraUrl = infuraUrls[chainId];
+  if (!infuraUrl) return undefined;
+  return `${infuraUrl}${apiKey}`;
+}

--- a/src/libs/ethersUtils.ts
+++ b/src/libs/ethersUtils.ts
@@ -3,6 +3,7 @@ import { type PublicClient, type WalletClient } from "wagmi";
 import { createPublicClient, http } from "viem";
 import { contractDataList } from ".";
 
+
 export function publicClientToProvider(publicClient: PublicClient) {
   const { chain, transport } = publicClient;
   const network = {
@@ -25,7 +26,7 @@ export function walletClientToSigner(walletClient: WalletClient) {
   return signer;
 }
 
-export function getPublicClient(chainId: number) {
+export function getPublicClient(chainId: number, providerUrl?:string) {
   const networkConfig = contractDataList.find(
     (chain) => chain.chainId === chainId,
   );
@@ -38,6 +39,6 @@ export function getPublicClient(chainId: number) {
       multicall: true,
     },
     chain: networkConfig.network,
-    transport: http(),
+    transport: http(providerUrl),
   });
 }

--- a/src/libs/ogSubgraph.ts
+++ b/src/libs/ogSubgraph.ts
@@ -23,7 +23,7 @@ export function Client(chainId: number) {
         }
       }
     `;
-    const response = await request<Response>(subgraph, gqlQuery);
+    const response = await request<Response>(subgraph, gqlQuery, {});
     // TODO: might be better to throw with descriptive message here
     if (!response.safe) {
       throw new Error("No module deployed on this safe", { cause: 404 });


### PR DESCRIPTION
# motivation
calls to the public provider are failing

# changes
the failing call is on a serverless function, so we can add an optional infura api key which is private and only fall back to public providers if that is not included

# testing
this can be tested by checking the linear issue and running the curl command against the preview url, you should see:
```
{
  "automaticExecution": true
}
```